### PR TITLE
Fix login page input field colors and ver 1.4

### DIFF
--- a/client/client.style.css
+++ b/client/client.style.css
@@ -24,6 +24,10 @@ label.Label-sc-g780ms-0.dqkKHi {
   color: var(--three) !important;
 }
 
+input.Input-sc-19rce1w-0.fFYzlR {
+  color: white !important;
+}
+
 a.GreyRowBox-sc-1xo9c6v-0.ServerRow__StatusIndicatorBox-sc-1ibsw91-2.dyLna-D.fRwFrz.DashboardContainer___StyledServerRow-sc-1topkxf-2 {
   background-color: var(--one) !important;
 }

--- a/conf.yml
+++ b/conf.yml
@@ -6,7 +6,7 @@ info:
   identifier: "recolor"
   description: "A Pterodactyl dark mode theme."
   flags: ""
-  version: "1.3"
+  version: "1.4"
   target: "alpha-L53"
   author: "sp11rum"
   icon: "assets/logo.jpg"


### PR DESCRIPTION
Changed login page input field colors from **gray/dark** color to **white**, making it easier to see.

This should only change the input field color on login page and nowhere else.

Version changed to **1.4** from **1.3** on conf.yml

**Before**:
![image_2023-11-30_144124196](https://github.com/sp11rum/recolor/assets/135278375/a9b7a604-4c54-4afd-a179-401d841829b8)

**After**:
![image_2023-11-30_144152403](https://github.com/sp11rum/recolor/assets/135278375/858d5fd0-fd6d-449d-b0bd-be82bf86cfb5)


